### PR TITLE
adding snmp if_octect support

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -18,6 +18,9 @@ $CONFIG['rrdtool_opts'] = '';
 # default plugins to show on host page
 $CONFIG['overview'] = array('load', 'cpu', 'memory', 'swap');
 
+# interface unit use bit instead of Byte 
+$CONFIG['interface_use_bit'] = false;
+
 # default plugins time range
 $CONFIG['time_range']['default'] = 86400;
 $CONFIG['time_range']['uptime']  = 31536000;

--- a/inc/collectd.inc.php
+++ b/inc/collectd.inc.php
@@ -107,7 +107,7 @@ function group_plugindata($plugindata) {
 	# type instances should be grouped in 1 graph
 	foreach ($plugindata as $item) {
 		# backwards compatibility
-		if ($CONFIG['version'] >= 5 || !preg_match('/^(df|interface)$/', $item['p']))
+		if ($CONFIG['version'] >= 5 || !preg_match('/^(df|interface|snmp)$/', $item['p']))
 			if($item['p'] != 'libvirt')
 				unset($item['ti']);
 		$data[] = $item;
@@ -171,7 +171,7 @@ function build_url($base, $items, $s=NULL) {
 		if ($value == 'NULL')
 			continue;
 
-		$base .= sprintf('%s%s=%s', $i==0 ? '?' : '&', $key, $value);
+		$base .= sprintf('%s%s=%s', $i==0 ? '?' : '&', $key, urlencode($value));
 		$i++;
 	}
 	if (!isset($items['s']))

--- a/plugin/interface.php
+++ b/plugin/interface.php
@@ -39,7 +39,14 @@ switch($obj->args['type']) {
 	break;
 	case 'if_octets':
 		$obj->rrd_title = sprintf('Interface Traffic (%s)', $obj->args[$instance]);
-		$obj->rrd_vertical = 'Bytes per second';
+		if ($CONFIG['interface_use_bit']) {
+			$obj->scale = 8;
+			$obj->rrd_vertical = 'Bits per second';
+		} else {
+			$obj->scale = 1;
+			$obj->rrd_vertical = 'Bytes per second';
+		}
+
 	break;
 	case 'if_packets':
 		$obj->rrd_title = sprintf('Interface Packets (%s)', $obj->args[$instance]);

--- a/plugin/snmp.php
+++ b/plugin/snmp.php
@@ -1,0 +1,51 @@
+<?php
+
+# Collectd Swap plugin
+
+require_once 'conf/common.inc.php';
+#require_once 'type/Default.class.php';
+require_once 'type/GenericIO.class.php';
+#require_once 'type/GenericStacked.class.php';
+require_once 'inc/collectd.inc.php';
+
+
+# LAYOUT 
+# snmp/
+# snmp/if_errors-XXXX.rrd
+# snmp/if_octets-XXXX.rrd
+# snmp/if_packets-XXXX.rrd
+
+$obj = new Type_GenericIO($CONFIG);
+
+$instance = $CONFIG['version'] < 5 ? 'tinstance' : 'pinstance';
+switch($obj->args['type']) {
+	case 'if_octets':
+		$obj->data_sources = array('rx', 'tx');
+		$obj->ds_names = array(
+			'rx' => 'Receive',
+			'tx' => 'Transmit',
+		);
+		$obj->colors = array(
+			'rx' => '0000ff',
+			'tx' => '00b000',
+		);
+		if ($CONFIG['interface_use_bit']) {
+			$obj->scale = 8;
+			$obj->rrd_vertical = 'Bits per second';
+		} else {
+			$obj->scale = 1;
+			$obj->rrd_vertical = 'Bytes per second';
+		}
+		$obj->width = $width;
+		$obj->heigth = $heigth;
+		$obj->rrd_format = '%5.1lf%s';
+		$obj->rrd_title = sprintf('Interface Traffic (%s)', $obj->args[$instance]);
+	break;
+	default:
+		# others are not supported yet
+	return;
+}
+
+
+collectd_flush($obj->identifiers);
+$obj->rrd_graph();


### PR DESCRIPTION
It seems snmp plugin is missing, so I wrote one. currently  tested with 

   <Data "std_traffic">
       Type "if_octets"
       Table true
       Instance "IF-MIB::ifDescr"
       Values "IF-MIB::ifInOctets" "IF-MIB::ifOutOctets"
   </Data>

I also added urlencode() for image url, because the rrd file may contain characters from interface description like "snmp/if_octets-Port #10.rrd"

At last I added a option $CONFIG['interface_use_bit'] = true   to toggle the netflow unit from Byte to Bit.

screenshot:
http://i.imgur.com/3BzzY.png
