### PR TITLE
Escape parentheses in filenames

### DIFF
--- a/type/Default.class.php
+++ b/type/Default.class.php
@@ -126,8 +126,8 @@ class Type_Default {
 			# rawurlencode all but /
 			$file = str_replace('%2F', '/', rawurlencode($file));
 		} else {
-			# escape spaces
-			$file = str_replace(' ', '\ ', $file);
+			# escape characters
+			$file = str_replace(array(' ', '(', ')'), array('\ ', '\(', '\)'), $file);
 		}
 		return $this->rrd_escape($file);
 	}


### PR DESCRIPTION
The IPMI collectd plugin uses parentheses in filenames (`fanspeed-FAN 1 fan_cooling (29.1).rrd`), so we need to escape them before passing them to rrdtool.

Fixes #30.
