### PR TITLE
Add default timezone when system one is missing

### DIFF
--- a/conf/common.inc.php
+++ b/conf/common.inc.php
@@ -4,3 +4,7 @@ require_once 'config.php';
 
 $CONFIG['webdir'] = preg_replace('/\/[a-z\.]+$/', '', $_SERVER['SCRIPT_FILENAME']);
 $CONFIG['weburl'] = preg_replace('/(?<=\/)[a-z\.]+$/', '', $_SERVER['SCRIPT_NAME']);
+
+if (!ini_get('date.timezone')) {
+	date_default_timezone_set($CONFIG['default_timezone']);
+}

--- a/conf/config.php
+++ b/conf/config.php
@@ -66,6 +66,9 @@ $CONFIG['detail-heigth'] = 350;
 # disabled: NULL
 $CONFIG['socket'] = NULL;
 
+# system default timezone when not set
+$CONFIG['default_timezone'] = 'UTC';
+
 
 # load local configuration
 if (file_exists(dirname(__FILE__).'/config.local.php'))


### PR DESCRIPTION
Suppresses all the PHP warnings in the error logging.
