### PR TITLE
Plugin template for curl_json

### DIFF
--- a/plugin/curl_json.php
+++ b/plugin/curl_json.php
@@ -1,0 +1,33 @@
+<?php
+
+# Collectd curl_json plugin
+
+require_once 'conf/common.inc.php';
+require_once 'inc/collectd.inc.php';
+require_once 'type/Default.class.php';
+$obj = new Type_Default($CONFIG);
+    
+switch($obj->args['type']) {
+  #COUNTER type example
+  case 'http_requests':
+    $obj->data_sources = array('count'); 
+    $obj->ds_names = array('count' => "PHP requests");
+    $obj->colors['count'] = '00b000';
+    unset($obj->ds_names['value']);   
+    $obj->rrd_title = $obj->args['type'].' of '.$obj->args['pinstance'];
+    $obj->rrd_vertical = 'con/s';
+    break;
+  
+  #Insert other COUNTER type values here
+  
+  #By default values counted as GAUGE
+  default:    
+    $obj->rrd_title = $obj->args['type'].' of '.$obj->args['pinstance'];
+    $obj->rrd_vertical = 'Count';    
+    break;
+}
+
+$obj->rrd_format = '%5.1lf%s';
+
+collectd_flush($obj->identifiers);
+$obj->rrd_graph();


### PR DESCRIPTION
This is template plugin for parsing values from curl_json.
Test set was: https://collectd.org/wiki/index.php/Plugin:cURL-JSON/phpfpm
Unfortunately it is need a special handling for COUNTER type values, so i dunno how to write universal plugin. Because there is no type (COUNTER/GAUGE) of value, as for 'tail' plugin in the rrd file name.
