### PR TITLE
overview: show rootfs usage percentage

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -26,9 +26,10 @@ $CONFIG['overview'] = array('load', 'cpu', 'memory', 'swap');
 $CONFIG['time_range']['default'] = 86400;
 $CONFIG['time_range']['uptime']  = 31536000;
 
-# show load averages and used memory on overview page
+# show load averages, memory and rootfs usage on overview page
 $CONFIG['showload'] = true;
 $CONFIG['showmem'] = true;
+$CONFIG['showroot'] = true;
 
 $CONFIG['term'] = array(
 	'2hour'	 => 3600 * 2,

--- a/inc/html.inc.php
+++ b/inc/html.inc.php
@@ -245,6 +245,29 @@ function host_summary($cat, $hosts) {
             }
         }
 
+        if ($CONFIG['showroot']) {
+            $rrd_info_df = $rrd->rrd_info($CONFIG['datadir'].'/'.$host.'/df/df-root.rrd');
+            
+            # ignore if file does not exist
+            if (!$rrd_info_df)
+                continue;
+
+            if (isset($rrd_info_df["ds[free].last_ds"])) {
+                $total_disk = $rrd_info_df["ds[used].last_ds"] + $rrd_info_df["ds[free].last_ds"];
+                # We assume 5% is allocated only for root because this is the default setting.
+                $percent_disk = ( $rrd_info_df["ds[used].last_ds"] + 5 * $total_disk / 100 ) * 100 / $total_disk;
+
+                $class = '';
+                if ($percent_disk > 90)
+                    $class = ' class="crit"';
+                elseif ($percent_disk > 70)
+                    $class = ' class="warn"';
+
+                printf('<td%s>%d</td>', $class, $percent_disk);
+            }
+        }
+
+
 		print "</tr>\n";
 	}
 


### PR DESCRIPTION
By default filesystems allocate 5% of the space to the root user.
We also include this even though the value can be tuned manually.
