### PR TITLE
Remove PHP warning when an unknown host is requested

### DIFF
--- a/inc/collectd.inc.php
+++ b/inc/collectd.inc.php
@@ -88,6 +88,8 @@ function collectd_plugindata($host, $plugin=NULL) {
 # returns an array of all plugins of a host
 function collectd_plugins($host) {
 	$plugindata = collectd_plugindata($host);
+	if (!$plugindata)
+		return array();
 
 	$plugins = array();
 	foreach ($plugindata as $item) {


### PR DESCRIPTION
When using an unknown host in queries, for example when going to `cgp/host.php?h=anUnknownHostWhichDoesNotExist`, PHP displays following warning right before a line containing `Unknown host`:

```
Warning: Invalid argument supplied for foreach() in /srv/http/cgp/inc/collectd.inc.php on line 93
```

This warning comes from `collectd_plugins()` which uses the return value of `collectd_plugindata()` in a `foreach` statement even though this value may be `false`. My commit removes the warning by directly returning an empty array if this value is `false` or empty. Feel free to change "empty array" to something else (like `false`?) if you think it's better.
