### PR TITLE
plugin: fix typo in temperature type

### DIFF
--- a/plugin/ipmi.json
+++ b/plugin/ipmi.json
@@ -4,7 +4,7 @@
 		"vertical": "RPM",
 		"legend_format": "%5.1lf"
 	},
-	"temerature": {
+	"temperature": {
 		"title": "Temperature ({{PI}})",
 		"vertical": "Celsius",
 		"legend_format": "%5.1lf%s"

--- a/plugin/sensors.json
+++ b/plugin/sensors.json
@@ -4,7 +4,7 @@
 		"vertical": "RPM",
 		"legend_format": "%5.1lf"
 	},
-	"temerature": {
+	"temperature": {
 		"title": "Temperature ({{PI}})",
 		"vertical": "Celsius",
 		"legend_format": "%5.1lf%s"


### PR DESCRIPTION
A "p" is missing in "temperature" in two plugin definitions. This typo has been detected thanks to a PHP warning in `graph.php` because `$plugin_json[$type]['type']` does not exist when `$type` is `"temerature"`.

After this patch, PHP still warns at the same line of `graph.php` about an non-existing item when using the sensors plugin to display temperature graphs because there is no `'type'` field. I don't know whether PHP has something like "get an item from an array of null if it doesn't exist" so `isset($plugin_json[$type]['type'])` seems to be required somewhere.

Moreover it might be useful to check whether `$plugin_json[$type]` exists after loading the plugin (`file_get_contents` + `json_decode`) and log an error if not. This would help to detect typos in plugins. What do you think of this idea?
