### PR TITLE
Keep the list of plugins sorted

### DIFF
--- a/inc/collectd.inc.php
+++ b/inc/collectd.inc.php
@@ -95,6 +95,7 @@ function collectd_plugins($host) {
 		if (!in_array($item['p'], $plugins))
 			$plugins[] = $item['p'];
 	}
+	sort($plugins);
 
 	return $plugins ? $plugins : false;
 }


### PR DESCRIPTION
The list of plugin on the host page is currently, as far as I can see, in random order.

I believe that making it ordered make it simpler to find each plugin

Feel free to reject the PR if this is an expected behaviour
