### PR TITLE
Use config time_range for canvas graphs

### DIFF
--- a/inc/html.inc.php
+++ b/inc/html.inc.php
@@ -305,6 +305,7 @@ function graphs_from_plugin($host, $plugin, $overview=false) {
 			isset($items['pi']) ? $_GET['pi'] = $items['pi'] : $_GET['pi'] = '';
 			isset($items['t']) ? $_GET['t'] = $items['t'] : $_GET['t'] = '';
 			isset($items['ti']) ? $_GET['ti'] = $items['ti'] : $_GET['ti'] = '';
+			$_GET['s'] = $time;
 			include $CONFIG['webdir'].'/graph.php';
 		} else {
 			printf('<a href="%s%s"><img src="%s%s"></a>'."\n",


### PR DESCRIPTION
Canvas graphs, when used, don't follow the time_range configuration option, and only use the default set in Base.class.php: 86400
