### PR TITLE
Naming schema

### DIFF
--- a/inc/collectd.inc.php
+++ b/inc/collectd.inc.php
@@ -48,7 +48,9 @@ function parse_file_path($path) {
 	$path = explode('.rrd', $path)[0];
 
 	list($plugin_data, $type_data) = explode('/', $path);
-	$plugin_data = explode('-', $plugin_data);
+	# Explode by first occurence of '-'
+	$plugin_data = explode('-', $plugin_data, 2);
+	# Explode by first occurence of '-'
 	$type_data = explode('-', $type_data, 2);
 
 	$data['p'] = $plugin_data[0];


### PR DESCRIPTION
This pull request follows [collectd naming schema](https://collectd.org/wiki/index.php/Naming_schema). Unfortunatelly I have no idea what is 'c' (category) key used for. In previous code I can see varnish in regexp. [Plugin page](https://collectd.org/wiki/index.php/Plugin:Varnish) does not mention anything unusual about naming schema.

Note:
This is not backwards compatible with collectd 4.x. Please see [this](https://collectd.org/wiki/index.php/Naming_schema#Plugin_instance_and_type_instance) for more information.
