### PR TITLE
Support customized RRD URLs

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -65,6 +65,11 @@ $CONFIG['graph_smooth'] = false;
 # draw min/max spikes in a lighter color in graphs with type default
 $CONFIG['graph_minmax'] = false;
 
+# The URL that provides RRD files for the "canvas" graph type. Examples:
+# 'rrd/{file}' is replaced by 'rrd/example.com/load/load.rrd'
+# 'rrd.php?path={file_escaped}' becomes 'rrd.php?path=host%3Fload%3Fload.rrd'
+$CONFIG['rrd_url'] = 'rrd.php?path={file_escaped}';
+
 # browser cache time for the graphs (in seconds)
 $CONFIG['cache'] = 90;
 

--- a/rrd.php
+++ b/rrd.php
@@ -4,7 +4,13 @@ require_once 'conf/common.inc.php';
 require_once 'inc/functions.inc.php';
 require_once 'inc/html.inc.php';
 
-if ( $file = validateRRDPath($CONFIG['datadir'], urldecode($_SERVER["QUERY_STRING"])) ) {
+$path = filter_input(INPUT_GET, 'path');
+if (!$path) {
+	// legacy option: rrd.php?some.host/load/load.rrd
+	$path = urldecode(filter_input(INPUT_SERVER, 'QUERY_STRING'));
+}
+
+if ( $file = validateRRDPath($CONFIG['datadir'], $path) ) {
 	header('Content-Type: application/octet-stream');
 	header('Content-Disposition: attachment; filename='.basename($file));
 	header("Expires: " .date(DATE_RFC822,strtotime($CONFIG['cache']." seconds")));
@@ -15,10 +21,11 @@ if ( $file = validateRRDPath($CONFIG['datadir'], urldecode($_SERVER["QUERY_STRIN
 	header('HTTP/1.0 403 Forbidden');
 
 	html_start();
+	$html_weburl = htmlentities($CONFIG['weburl']);
 	echo <<<EOT
 <fieldset id="forbidden">
 <legend>forbidden</legend>
-<p><a href="{$CONFIG['weburl']}">Return home...</a></p>
+<p><a href="{$html_weburl}">Return home...</a></p>
 </fieldset>
 
 EOT;

--- a/type/Base.class.php
+++ b/type/Base.class.php
@@ -6,6 +6,7 @@ class Type_Base {
 	var $datadir;
 	var $rrdtool;
 	var $rrdtool_opts = array();
+	var $rrd_url;
 	var $cache;
 	var $args;
 	var $seconds;
@@ -44,6 +45,7 @@ class Type_Base {
 						$config['rrdtool_opts']);
 			}
 		}
+		$this->rrd_url = $config['rrd_url'];
 		$this->cache = $config['cache'];
 		$this->parse_get($_get);
 		$this->rrd_title = sprintf(
@@ -137,6 +139,9 @@ class Type_Base {
 	}
 
 	function rrd_escape($value) {
+		# In case people have really bizarre URLs in $CONFIG['rrd_url'],
+		# it should not be dropped.
+		return str_replace('\\', '\\\\', $value);
 		# http://oss.oetiker.ch/rrdtool/doc/rrdgraph_graph.en.html#IEscaping_the_colon
 		return str_replace(':', '\:', $value);
 	}
@@ -144,10 +149,11 @@ class Type_Base {
 	function parse_filename($file) {
 		if ($this->graph_type == 'canvas') {
 			$file = str_replace($this->datadir . '/', '', $file);
-			# rawurlencode all but /
-			$file = 'rrd.php?' . str_replace('%2F', '/', rawurlencode($file));
+			$rrd_url = str_replace('{file}', $file, $this->rrd_url);
+			$rrd_url = str_replace('{file_escaped}',
+					urlencode($file), $rrd_url);
 		}
-		return $this->rrd_escape($file);
+		return $this->rrd_escape($rrd_url);
 	}
 
 	function rrd_files() {


### PR DESCRIPTION
Use case: I would like to bypass PHP for serving the RRD files and allow
the webserver (nginx) to compress it to reduce load on the Raspberry Pi.
I could go through all kinds of URL rewriting, but it is much easier to
set `$CONFIG['rrd_url'] = 'rrd/{file}';` instead and add a corresponding
location + alias directive to the nginx configuration.

This depends on https://github.com/manuelluis/jsrrdgraph/pull/17 to avoid breaking on `=`.

Both forms are tested and are correctly processed (provided that you include that jsrrdgraph patch!).
