### PR TITLE
Allow users to override plugin json without having to modify source

### DIFF
--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,1 +1,2 @@
 config.local.php
+plugin

--- a/graph.php
+++ b/graph.php
@@ -52,7 +52,6 @@ if(function_exists('json_decode'))
 			error_log('CGP Error: invalid json in conf/plugin/'.$plugin.'.json');
 
 		$plugin_json = array_replace_recursive($plugin_json, $user_plugin_json);
-		//die(var_dump($plugin_json));
 	}
 }
 

--- a/graph.php
+++ b/graph.php
@@ -35,12 +35,25 @@ if ($plugin == 'aggregation') {
 }
 
 # plugin json
-if (function_exists('json_decode') && file_exists('plugin/'.$plugin.'.json')) {
-	$json = file_get_contents('plugin/'.$plugin.'.json');
-	$plugin_json = json_decode($json, true);
+if(function_exists('json_decode'))
+{
+	if (file_exists('plugin/'.$plugin.'.json')) {
+		$json = file_get_contents('plugin/'.$plugin.'.json');
+		$plugin_json = json_decode($json, true);
 
-	if (is_null($plugin_json))
-		error_log('CGP Error: invalid json in plugin/'.$plugin.'.json');
+		if (is_null($plugin_json))
+			error_log('CGP Error: invalid json in plugin/'.$plugin.'.json');
+	}
+	if (file_exists('conf/plugin/'.$plugin.'.json')) {
+		$json = file_get_contents('conf/plugin/'.$plugin.'.json');
+		$user_plugin_json = json_decode($json, true);
+
+		if (is_null($user_plugin_json))
+			error_log('CGP Error: invalid json in conf/plugin/'.$plugin.'.json');
+
+		$plugin_json = array_replace_recursive($plugin_json, $user_plugin_json);
+		//die(var_dump($plugin_json));
+	}
 }
 
 if (!isset($plugin_json[$type]['type']))


### PR DESCRIPTION
Hi,

Currently if we want to change a plugin, then we have to modify the plugins folder that ships with CGP, which causes issues with updates.  This patch adds a new folder conf/plugin in which the user can specify his own json to override the default stuff.

This loads the default json, and then loads the user's json and overrides the default stuff.  I did it this way as otherwise the user would have to copy the whole file, which has issues with updates.  With this the user can make a json file with just a couple of lines to just change the bits they want.
