### PR TITLE
PHP files cache now expires after 30 seconds

### DIFF
--- a/doc/nginx.conf
+++ b/doc/nginx.conf
@@ -32,6 +32,7 @@ server {
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         include        fastcgi_params;
+        expires 30;
     }
 
     # Disallow access to hidden files and directories (such as .git/)


### PR DESCRIPTION
PHP files should expire very often, in this PR after 30 seconds. This is because with the current `master` nginx configuration file, when navigating through pages the browser keeps the cache even for hours, so that graphs and "instant" values on the home of CGP are often outdated.