### PR TITLE
Fixes array_search comparison.

### DIFF
--- a/type/Base.class.php
+++ b/type/Base.class.php
@@ -285,7 +285,7 @@ class Type_Base {
 			$rrdgraph[] = '--base';
 			$rrdgraph[] = $this->base;
 		}
-		if (!array_search('-l', $rrdgraph)) {
+		if (array_search('-l', $rrdgraph) === false) {
 			$rrdgraph[] = '-l';
 			$rrdgraph[] = '0';
 		}


### PR DESCRIPTION
# Test case
A plugin defines a custom `-l` parameter.
If this parameter is in the first position of the `rrdtool_opts` array, the default `-l` argument will still be appended.
# Solution
Use `===` instead of a simple `==` comparison.
See http://php.net/manual/en/function.array-search.php for more details.