### PR TITLE
Add View for Groups

### DIFF
--- a/group.php
+++ b/group.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once 'conf/common.inc.php';
+require_once 'inc/html.inc.php';
+require_once 'inc/collectd.inc.php';
+
+header("Content-Type: text/html");
+
+$category = GET('h');
+$plugin = GET('p');
+
+$selected_plugins = !$plugin ? $CONFIG['overview'] : array($plugin);
+
+html_start();
+
+echo "<h1>$category</h1>";
+
+$host = $CONFIG['cat'][$category][0];
+
+printf("<fieldset id=\"%s\">", htmlentities($host));
+printf("<legend>%s</legend>", htmlentities($host));
+
+		echo <<<EOT
+<input type="checkbox" id="navicon" class="navicon" />
+<label for="navicon"></label>
+
+EOT;
+
+if (!strlen($host) || !$plugins = collectd_plugins($host)) {
+	echo "Unknown host\n";
+	return false;
+}
+
+plugins_list_group($category, $selected_plugins);
+
+echo $CONFIG['cat'][$category];
+
+echo '<div class="graphs">';
+foreach ($selected_plugins as $selected_plugin) {
+	plugin_header($host, $selected_plugin);
+	if (in_array($selected_plugin, $plugins)) {
+		foreach ($CONFIG['cat'][$category] as $host) {
+			graphs_from_plugin($host, $selected_plugin, empty($plugin));
+		}
+	}
+}
+echo '</div>';
+printf("</fieldset>");
+
+html_end();

--- a/inc/html.inc.php
+++ b/inc/html.inc.php
@@ -151,6 +151,51 @@ function plugin_header($host, $plugin) {
 		htmlentities($plugin));
 }
 
+function plugins_list_group($group, $selected_plugins = array()) {
+	global $CONFIG;
+
+	$plugins = collectd_plugins( $CONFIG['cat'][$group][0]);
+
+	echo '<div class="plugins">';
+	echo '<h2>Plugins</h2>';
+	echo '<ul>';
+
+	printf("<li><a %shref=\"%sgroup.php?h=%s\">overview</a></li>\n",
+		selected_overview($selected_plugins),
+		htmlentities($CONFIG['weburl']),
+		urlencode($group)
+	);
+
+	# first the ones defined as ordered
+	foreach($CONFIG['overview'] as $plugin) {
+		if (in_array($plugin, $plugins)) {
+			printf("<li><a %shref=\"%sgroup.php?h=%s&amp;p=%s\">%s</a></li>\n",
+				selected_plugin($plugin, $selected_plugins),
+				htmlentities($CONFIG['weburl']),
+				urlencode($group),
+				urlencode($plugin),
+				htmlentities($plugin)
+			);
+		}
+	}
+
+	# other plugins
+	foreach($plugins as $plugin) {
+		if (!in_array($plugin, $CONFIG['overview'])) {
+			printf("<li><a %shref=\"%sgroup.php?h=%s&amp;p=%s\">%s</a></li>\n",
+				selected_plugin($plugin, $selected_plugins),
+				htmlentities($CONFIG['weburl']),
+				urlencode($group),
+				urlencode($plugin),
+				htmlentities($plugin)
+			);
+		}
+	}
+
+	echo '</ul>';
+	echo '</div>';
+}
+
 function plugins_list($host, $selected_plugins = array()) {
 	global $CONFIG;
 
@@ -223,7 +268,10 @@ function host_summary($cat, $hosts) {
 	$rrd = new RRDTool($CONFIG['rrdtool']);
 
 	printf('<fieldset id="%s">', htmlentities($cat));
-	printf('<legend>%s</legend>', htmlentities($cat));
+	printf('<legend><a href="%sgroup.php?h=%s">%s</a></legend>',
+		   htmlentities($CONFIG['weburl']),
+		   htmlentities($cat),
+		   htmlentities($cat));
 	echo "<div class=\"summary\">\n";
 
 	$row_style = array(0 => "even", 1 => "odd");


### PR DESCRIPTION
With this commit server groups have their own view.
That is: for any given metric the charts for all the servers of a group is shown.


Example:

![Example](https://user-images.githubusercontent.com/12686782/29244762-2b71cac8-7fc1-11e7-95f5-bce8ba935d50.png)
