### PR TITLE
Add Dockerfile based on php:7.1-apache image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.gitignore
+doc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.1-apache
+
+RUN apt-get update &&\
+    apt-get install -y rrdtool &&\
+    a2enmod rewrite &&\
+    rm -rf /var/lib/apt/lists/*
+COPY . /var/www/html/
+RUN sed -i "s/\$CONFIG\['graph_type'\].*$/\$CONFIG['graph_type'] = 'canvas';/" /var/www/html/conf/config.php


### PR DESCRIPTION
Hello, I wanted to test CGP but not having any apache+PHP server available I made a `Dockerfile`.

I made a master build available at https://quay.io/repository/nolith/cgp

In general, if you want to build it yourself it's just 

`docker build -t cgp .`

And then you can run it with

```bash
docker run --rm -p 8080:80 \
  -v /path/to/your/rdd:/var/lib/collectd/rrd \
  -v /usr/share/collectd:/usr/share/collectd:ro \
  cgp
```
and then open http://localhost:8080
