### PR TITLE
Add configuration option to disable warning

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -3,6 +3,9 @@
 # collectd version
 $CONFIG['version'] = 5;
 
+# show collectd 4 deprecation warning
+$CONFIG['version_warn'] = true;
+
 # collectd's datadir
 $CONFIG['datadir'] = '/var/lib/collectd/rrd';
 

--- a/inc/html.inc.php
+++ b/inc/html.inc.php
@@ -77,7 +77,7 @@ EOT;
 
 	}
 
-	if($CONFIG['version'] == 4) {
+	if($CONFIG['version'] == 4 && $CONFIG['version_warn']) {
 		echo <<<EOT
 <div class="warnheader">
 	You are using Collectd 4, which is deprecated by CGP. Graphs like


### PR DESCRIPTION
This PR adds support for a configuration option which disables the deprecation warning present when using CGP with collectd 4.
(As an aside, I'm currently packaging CGP for EPEL 6 targets, which are tied to collectd 4 for the foreseeable future, so having an option to disable the nag is nice to have since it is straightforward to fix the `df` and `interfaces` plugins with a local json plugin.