### PR TITLE
functions.inc.php: escape minus in regex

### DIFF
--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -34,7 +34,7 @@ function GET($index = NULL, $value = NULL) {
 		case 'h': # host
 		case 'pi': # plugin instance
 		case 'ti': # type instance
-			if (!preg_match('/^[\w-.: ]+$/u', $value)) {
+			if (!preg_match('/^[\w\-.: ]+$/u', $value)) {
 				error_log(sprintf('Invalid %s in $_GET["%s"]: "%s"', $desc[$index], $index, $value));
 				return NULL;
 			}


### PR DESCRIPTION
This makes CGP work on PHP 7.3 as it otherwise only shows an "Unknown
host" error message and logs the following PHP warning:

PHP Warning:  preg_match(): Compilation failed: invalid range in
character class at offset 4 in .../inc/functions.inc.php on line 37

Apart from that, CGP seems to work fine with PHP 7.3.