### PR TITLE
List collectd plugins without rrd files enumeration

### DIFF
--- a/inc/collectd.inc.php
+++ b/inc/collectd.inc.php
@@ -90,15 +90,18 @@ function collectd_plugindata($host, $plugin=NULL) {
 
 # returns an array of all plugins of a host
 function collectd_plugins($host) {
-	if (!$plugindata = collectd_plugindata($host))
+	global $CONFIG;
+	$hostdir = $CONFIG['datadir'].'/'.$host;
+	if (!is_dir($hostdir))
 		return false;
 
+	$plugin_dirs = glob($hostdir .'/*', GLOB_ONLYDIR);
 	$plugins = array();
-	foreach ($plugindata as $item) {
-		if (!in_array($item['p'], $plugins))
-			$plugins[] = $item['p'];
+	foreach($plugin_dirs as $item) {
+		preg_match('#/([\w_]+)[^/]*$#', $item, $matches);
+		if (!in_array($matches[1], $plugins))
+			$plugins[] = $matches[1];
 	}
-	sort($plugins);
 
 	return $plugins ? $plugins : false;
 }


### PR DESCRIPTION
There are 2 motives for the change:

1) Before the change CGP enumerated all rrd files to display graph.php
or host.php and therefore broke if any single plugin directory lacks
read permissions.

2) With active `open_basedir` PHP option recursive scan becomes really
slow. Avoiding it gives huge speedup. For example on Core i5 and ~1300
rrd files:
graph.php: 907 ms -> 31 ms
host.php: 1372 ms -> 480 ms