### PR TITLE
js/CGP: Disable page refesh when scrolling or zooming a graph

### DIFF
--- a/js/CGP.js
+++ b/js/CGP.js
@@ -20,6 +20,7 @@ var CGP = (function() {
             } catch (ex) {
                 console.error('mouse_move:', ex, ex.stack);
             }
+            window.stop();
         }
     };
     var mouse_up = function(e) {
@@ -55,6 +56,7 @@ var CGP = (function() {
             } catch (ex) {
                 console.error('mouse_scroll:', ex, ex.stack);
             }
+            window.stop();
         }
 
         if (e.stopPropagation)


### PR DESCRIPTION
When scrolling or zooming a graph we want to disable the page refresh because we are trying to look at the detail. Unfortunately
Javascript cannot override the refresh meta tag;

`<meta http-equiv="refresh" content="{$CONFIG['page_refresh']}">`

Except with a window.stop() which is brutal but since the complete RRD data has already been read this is not an issue.

See issue #139 suggesting submitting a PR to refresh RRD data whilst a graph is scrolled or zoomed.