### PR TITLE
Added headers to the overview page that describe the displayed values

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -37,6 +37,9 @@ $CONFIG['showload'] = true;
 $CONFIG['showmem'] = false;
 $CONFIG['showtime'] = false;
 
+# display headers for the summary on overview page
+$CONFIG['summary_header'] = false;
+
 $CONFIG['term'] = array(
 	'2hour'	 => 3600 * 2,
 	'8hour'	 => 3600 * 8,

--- a/inc/html.inc.php
+++ b/inc/html.inc.php
@@ -226,6 +226,20 @@ function host_summary($cat, $hosts) {
 	printf('<legend>%s</legend>', htmlentities($cat));
 	echo "<div class=\"summary\">\n";
 
+	# Headers: Show descriptions of the stats displayed
+	if ($CONFIG['summary_header']) {
+		echo "<div class=\"row odd summary-header\"><label>name</label><div class=\"hostinfo\">";
+		if ($CONFIG['showload']) {
+			echo "<div class=\"field\" title=\"The short-term load\">short</div><div class=\"field\" title=\"The mid-term load\">mid</div><div class=\"field\" title=\"The long-term load\">long</div>";
+		}
+
+		if ($CONFIG['showmem']) {
+			echo "<div class=\"field\" title=\"The amount of utilized memory\">mem</div>";
+		}
+
+		echo "</div></div>";	
+	}
+
 	$row_style = array(0 => "even", 1 => "odd");
 	$host_counter = 0;
 

--- a/layout/style.css
+++ b/layout/style.css
@@ -103,6 +103,10 @@ a:hover {
 	width: 8em;
 }
 
+.summary-header {
+	opacity: 0.6;
+}
+
 img {
 	border: 0;
 }


### PR DESCRIPTION
We have added headers to the the overview page so that we know which values are displayed. It's not really tested on different configs, but works for us.

Headers have been added for 

 - short-term load, mid-term load and long-term load
 - utilized memory

depending on whether these values are enabled in the config.

The headers are disabled by default and can be enabled by setting `$CONFIG['summary_header'] = true;`.